### PR TITLE
Add OptirrigTOOLS and OptirrigVIEW to the INRAE R-universe registry.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -39,5 +39,15 @@
         "package": "OptirrigCORE",
         "url": "https://forge.inrae.fr/OptirrigHIVE/OptirrigCORE",
         "branch": "main"
-    }        
+    },
+        {
+        "package": "OptirrigTOOLS",
+        "url": "https://forge.inrae.fr/OptirrigHIVE/OptirrigTOOLS",
+        "branch": "main"
+    },
+        {
+        "package": "OptirrigVIEW",
+        "url": "https://forge.inrae.fr/OptirrigHIVE/OptirrigVIEW",
+        "branch": "main"
+    }
 ]


### PR DESCRIPTION
OptirrigTOOLS is an add-on package for OptirrigCORE that provides calibration, analysis, and statistical functions.
OptirrigVIEW is an add-on package for OptirrigCORE that provides functions to visualize and explore CORE outputs.
Both packages are public and intended to complement the OptirrigCORE ecosystem.